### PR TITLE
BigQuery (Server Route)

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 import flask
 import flask_cors
 from dotenv import load_dotenv
-from utilities import genius, firebase
+from utilities import genius, firebase, bigquery
 
 load_dotenv()
 
@@ -55,3 +55,12 @@ def get_recommendation():
     song_id = firebase.get_song_id(id_token)
     song = genius.get_song(song_id)
     return flask.jsonify(song)
+
+@app.route('/_likes')
+def get_likes():
+    """Gets verified user's liked songs"""
+    id_token = flask.request.headers['Authorization'].split(' ').pop()
+    if not firebase.logged_in(id_token):
+        return flask.abort(401, 'User not logged in!')
+    likes = bigquery.get_likes(id_token)
+    return flask.jsonify(likes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask-cors==1.10.3
 attrs==19.3.0
 gunicorn==20.0.4
 firebase-admin==4.3.0
+google-cloud-bigquery==1.28.0

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,10 +1,13 @@
 import {NgModule} from '@angular/core';
 import {Routes, RouterModule} from '@angular/router';
+
 import {HomeComponent} from './home/home.component';
+import {LikesComponent} from './likes/likes.component';
 
 const routes: Routes = [
   {path: '', redirectTo: '/', pathMatch: 'full'},
   {path: '', component: HomeComponent},
+  {path: 'likes', component: LikesComponent},
   {path: '**', redirectTo: '/', pathMatch: 'full'},
 ];
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,18 @@
 <div class="mat-app-background">
   <nav>
-    <a mat-icon-button routerLink="/"><mat-icon>album</mat-icon></a>
-    <a mat-icon-button routerLink="/likes"><mat-icon>queue_music</mat-icon></a>
+    <a mat-icon-button title="Recommendation" routerLink="/"
+      ><mat-icon>album</mat-icon></a
+    >
+    <a mat-icon-button title="Likes" routerLink="/likes"
+      ><mat-icon>queue_music</mat-icon></a
+    >
+    <a
+      mat-icon-button
+      title="Sign Out"
+      style="float: right;"
+      (click)="authService.signOut()"
+      ><mat-icon>directions_run</mat-icon></a
+    >
   </nav>
   <router-outlet></router-outlet>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,7 @@
-<router-outlet></router-outlet>
+<div class="mat-app-background">
+  <nav>
+    <a mat-icon-button routerLink="/"><mat-icon>album</mat-icon></a>
+    <a mat-icon-button routerLink="/likes"><mat-icon>queue_music</mat-icon></a>
+  </nav>
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,11 +1,12 @@
 import {TestBed, async} from '@angular/core/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {AppComponent} from './app.component';
+import {MatIconModule} from '@angular/material/icon';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, MatIconModule],
       declarations: [AppComponent],
     }).compileComponents();
   }));

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,19 +1,109 @@
-import {TestBed, async} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
+import {TestBed, ComponentFixture, async, inject} from '@angular/core/testing';
+import {Router} from '@angular/router';
+import {By} from '@angular/platform-browser';
+
 import {AppComponent} from './app.component';
+import {LikesComponent} from './likes/likes.component';
+
+import {AuthService} from './auth.service';
+
+import {Location, CommonModule} from '@angular/common';
+import {RouterTestingModule} from '@angular/router/testing';
 import {MatIconModule} from '@angular/material/icon';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import {AngularFireModule} from '@angular/fire';
+
+import {environment} from '../environments/environment';
 
 describe('AppComponent', () => {
+  let component: AppComponent;
+  let fixture: ComponentFixture<AppComponent>;
+
+  const mockWindow = {
+    location: jasmine.createSpyObj('location', ['reload']),
+  };
+
+  const mockAuthService = jasmine.createSpyObj('AuthService', {
+    signOut: Promise.resolve(() => {}),
+  });
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, MatIconModule],
+      imports: [
+        CommonModule,
+        RouterTestingModule.withRoutes([
+          {path: 'likes', component: LikesComponent},
+        ]),
+        MatIconModule,
+        HttpClientTestingModule,
+        AngularFireModule.initializeApp(environment.firebaseConfig),
+      ],
       declarations: [AppComponent],
+      providers: [
+        {provide: AuthService, useValue: mockAuthService},
+        {provide: Window, useValue: mockWindow},
+      ],
     }).compileComponents();
   }));
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should route to the _home_ URL', async(
+    inject([Router, Location], (router: Router, location: Location) => {
+      const expected_location = '/';
+
+      const rendered_location = fixture.debugElement
+        .query(By.css('a[title="Recommendation"]'))
+        .nativeElement.getAttribute('href');
+
+      expect(rendered_location).toEqual(expected_location);
+
+      fixture.debugElement
+        .query(By.css('a[title="Recommendation"]'))
+        .nativeElement.click();
+
+      fixture.whenStable().then(() => {
+        expect(location.path()).toEqual(expected_location);
+      });
+    })
+  ));
+
+  it('should route to the _likes_ URL', async(
+    inject([Router, Location], (router: Router, location: Location) => {
+      const expected_location = '/likes';
+
+      const rendered_location = fixture.debugElement
+        .query(By.css('a[title="Likes"]'))
+        .nativeElement.getAttribute('href');
+
+      expect(rendered_location).toEqual(expected_location);
+
+      fixture.debugElement
+        .query(By.css('a[title="Likes"]'))
+        .nativeElement.click();
+
+      fixture.whenStable().then(() => {
+        expect(location.path()).toEqual(expected_location);
+      });
+    })
+  ));
+
+  it('should sign the user out', () => {
+    fixture.debugElement
+      .query(By.css('a[title="Sign Out"]'))
+      .nativeElement.click();
+
+    expect(mockAuthService.signOut).toHaveBeenCalled();
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,15 +1,12 @@
 import {TestBed, ComponentFixture, async, inject} from '@angular/core/testing';
-import {Router} from '@angular/router';
 import {By} from '@angular/platform-browser';
 
 import {AppComponent} from './app.component';
-import {LikesComponent} from './likes/likes.component';
-
 import {AuthService} from './auth.service';
 
-import {Location, CommonModule} from '@angular/common';
 import {RouterTestingModule} from '@angular/router/testing';
 import {MatIconModule} from '@angular/material/icon';
+
 import {
   HttpClientTestingModule,
   HttpTestingController,
@@ -33,10 +30,7 @@ describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        CommonModule,
-        RouterTestingModule.withRoutes([
-          {path: 'likes', component: LikesComponent},
-        ]),
+        RouterTestingModule.withRoutes([]),
         MatIconModule,
         HttpClientTestingModule,
         AngularFireModule.initializeApp(environment.firebaseConfig),
@@ -59,45 +53,25 @@ describe('AppComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should route to the _home_ URL', async(
-    inject([Router, Location], (router: Router, location: Location) => {
-      const expected_location = '/';
+  it('should render route to the _home_ URL', () => {
+    const expected_location = '/';
 
-      const rendered_location = fixture.debugElement
-        .query(By.css('a[title="Recommendation"]'))
-        .nativeElement.getAttribute('href');
+    const rendered_location = fixture.debugElement
+      .query(By.css('a[title="Recommendation"]'))
+      .nativeElement.getAttribute('href');
 
-      expect(rendered_location).toEqual(expected_location);
+    expect(rendered_location).toEqual(expected_location);
+  });
 
-      fixture.debugElement
-        .query(By.css('a[title="Recommendation"]'))
-        .nativeElement.click();
+  it('should render route to the _likes_ URL', () => {
+    const expected_location = '/likes';
 
-      fixture.whenStable().then(() => {
-        expect(location.path()).toEqual(expected_location);
-      });
-    })
-  ));
+    const rendered_location = fixture.debugElement
+      .query(By.css('a[title="Likes"]'))
+      .nativeElement.getAttribute('href');
 
-  it('should route to the _likes_ URL', async(
-    inject([Router, Location], (router: Router, location: Location) => {
-      const expected_location = '/likes';
-
-      const rendered_location = fixture.debugElement
-        .query(By.css('a[title="Likes"]'))
-        .nativeElement.getAttribute('href');
-
-      expect(rendered_location).toEqual(expected_location);
-
-      fixture.debugElement
-        .query(By.css('a[title="Likes"]'))
-        .nativeElement.click();
-
-      fixture.whenStable().then(() => {
-        expect(location.path()).toEqual(expected_location);
-      });
-    })
-  ));
+    expect(rendered_location).toEqual(expected_location);
+  });
 
   it('should sign the user out', () => {
     fixture.debugElement

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,13 @@
 import {Component} from '@angular/core';
 
+import {AuthService} from './auth.service';
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
+  constructor(public authService: AuthService) {}
   title = 'noon';
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import {HttpClientModule} from '@angular/common/http';
 import {AppRoutingModule} from './app-routing.module';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MaterialModule} from './material/material.module';
+import {MatGridListModule} from '@angular/material/grid-list';
 import {AngularFireModule} from '@angular/fire';
 import {SafePipeModule} from 'safe-pipe';
 
@@ -26,6 +27,7 @@ import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
     BrowserAnimationsModule,
     FormsModule,
     MaterialModule,
+    MatGridListModule,
     HttpClientModule,
     SafePipeModule,
     AngularFireModule.initializeApp(environment.firebaseConfig),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {SafePipeModule} from 'safe-pipe';
 
 import {AppComponent} from './app.component';
 import {HomeComponent} from './home/home.component';
+import {LikesComponent} from './likes/likes.component';
 
 import {AuthService} from './auth.service';
 
@@ -18,7 +19,7 @@ import {environment} from '../environments/environment';
 import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 
 @NgModule({
-  declarations: [AppComponent, HomeComponent],
+  declarations: [AppComponent, HomeComponent, LikesComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -11,6 +11,7 @@ import {AngularFireAuth} from '@angular/fire/auth';
 import {auth} from 'firebase/app';
 
 import {Recommendation} from './models/recommendation.model';
+import {Like} from './models/like.model';
 import {environment} from '../environments/environment';
 
 describe('AuthService', () => {
@@ -84,12 +85,33 @@ describe('AuthService', () => {
     expect(mockAngularFireAuth.signOut).toHaveBeenCalled();
   });
 
+  it('should make HTTP request for liked songs', inject(
+    [HttpTestingController, AuthService],
+    (httpMock: HttpTestingController, authService: AuthService) => {
+      const idToken = 'idToken';
+
+      const likes: Like[] = [
+        {uid: 'uid1', id: 0},
+        {uid: 'uid1', id: 1},
+      ];
+
+      authService.getLikes(idToken).subscribe(response => {
+        expect(response['likes']).toEqual(likes);
+      });
+
+      const req = httpMock.expectOne(environment.url + '_likes');
+      expect(req.request.method).toEqual('GET');
+
+      req.flush({likes: likes});
+    }
+  ));
+
   it('should make HTTP request for song recommendation', inject(
     [HttpTestingController, AuthService],
     (httpMock: HttpTestingController, authService: AuthService) => {
       const idToken = 'idToken';
 
-      const recommendation = {
+      const recommendation: Recommendation = {
         album: 'Djesse, Vol. 3',
         apple_music_player_url:
           'https://genius.com/songs/5751704/apple_music_player',

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -10,6 +10,7 @@ import * as firebase from 'firebase';
 import {AngularFireAuth} from '@angular/fire/auth';
 
 import {Recommendation} from './models/recommendation.model';
+import {Like} from './models/like.model';
 import {environment} from '../environments/environment';
 
 @Injectable({
@@ -36,6 +37,13 @@ export class AuthService {
       song.album = 'Non-Album Single';
     }
     return song;
+  }
+
+  /** Returns an Observable for the songs liked by the signed-in user. */
+  getLikes(idToken): Observable<any> {
+    return this.http.get<Like[]>(environment.url + '_likes', {
+      headers: this.headers.append('Authorization', 'Bearer ' + idToken),
+    });
   }
 
   /** Returns an Observable for a song recommendation to the signed-in user. */

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -54,12 +54,12 @@ export class AuthService {
   /** Authenticates a user, if not signed in, and returns an Observable for their ID token. */
   authenticateWithGoogle(): Observable<string> {
     return from(this.user).pipe(
-      flatMap(user => {
-        return from(
+      flatMap(user =>
+        from(
           user ? Promise.resolve()
                : this.auth.signInWithPopup(new auth.GoogleAuthProvider())
-        );
-      }),
+        )
+      ),
       flatMap(() => from(this.auth.currentUser)),
       flatMap(user => {
         if (!user) throw new Error('No user signed in.');

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -55,17 +55,15 @@ export class AuthService {
   authenticateWithGoogle(): Observable<string> {
     return from(this.user).pipe(
       flatMap(user => {
-        const authPromise = user
-          ? Promise.resolve()
-          : this.auth.signInWithPopup(new auth.GoogleAuthProvider());
-        return from(authPromise).pipe(
-          flatMap(() => {
-            return this.auth.currentUser.then(user => {
-              if (user == null) throw new Error('No user signed in.');
-              return user.getIdToken();
-            });
-          })
+        return from(
+          user ? Promise.resolve()
+               : this.auth.signInWithPopup(new auth.GoogleAuthProvider())
         );
+      }),
+      flatMap(() => from(this.auth.currentUser)),
+      flatMap(user => {
+        if (!user) throw new Error('No user signed in.');
+        return user.getIdToken();
       })
     );
   }

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -24,7 +24,7 @@ export class AuthService {
     private auth: AngularFireAuth,
     private window: Window
   ) {
-    this.user = new Promise((resolve, reject) => {
+    this.user = new Promise(resolve => {
       this.auth.onAuthStateChanged(user => resolve(user));
     });
   }

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -40,14 +40,14 @@ export class AuthService {
   }
 
   /** Returns an Observable for the songs liked by the signed-in user. */
-  getLikes(idToken): Observable<any> {
+  getLikes(idToken: string): Observable<Like[]> {
     return this.http.get<Like[]>(environment.url + '_likes', {
       headers: this.headers.append('Authorization', 'Bearer ' + idToken),
     });
   }
 
   /** Returns an Observable for a song recommendation to the signed-in user. */
-  getRecommendation(idToken): Observable<Recommendation> {
+  getRecommendation(idToken: string): Observable<Recommendation> {
     return this.http
       .get<Recommendation>(environment.url + '_recommend', {
         headers: this.headers.append('Authorization', 'Bearer ' + idToken),

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,7 +1,6 @@
 :host {
   align-items: center;
   display: flex;
-  height: 95%;
   justify-content: center;
 }
 
@@ -16,5 +15,6 @@
 
 .mat-card {
   background: #717f77;
+  margin-top: 23vh;
   width: 75%;
 }

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,8 +1,7 @@
 :host {
   align-items: center;
-  background: #f1f1e7;
   display: flex;
-  height: 100%;
+  height: 95%;
   justify-content: center;
 }
 

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -22,9 +22,6 @@
         [attr.href]="recommendation.url"
         ><mat-icon>article</mat-icon>
       </a>
-      <a mat-icon-button title="Sign out" (click)="authService.signOut()"
-        ><mat-icon>exit_to_app</mat-icon></a
-      >
     </mat-card-actions>
   </mat-card>
 </ng-container>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -34,6 +34,7 @@ describe('HomeComponent', () => {
   let getRecommendationSpy;
 
   const idToken: string = 'idT0ken';
+
   const recommendation: Recommendation = {
     album: 'Djesse, Vol. 3',
     apple_music_player_url:

--- a/src/app/likes/likes.component.css
+++ b/src/app/likes/likes.component.css
@@ -1,9 +1,9 @@
 :host {
   align-items: center;
+  color: #717f77;
   display: flex;
   height: 95%;
   justify-content: center;
-  color: #717f77;
 }
 
 ::ng-deep .mat-progress-spinner circle,

--- a/src/app/likes/likes.component.css
+++ b/src/app/likes/likes.component.css
@@ -1,9 +1,7 @@
 :host {
   align-items: center;
   display: flex;
-  height: 95%;
   justify-content: center;
-  color: #717f77;
 }
 
 ::ng-deep .mat-progress-spinner circle,
@@ -11,6 +9,7 @@
   stroke: #dae59b;
 }
 
-.mat-list-item {
-  color: #717f77;
+.mat-grid-list {
+  margin-top: 3vh;
+  width: 75%;
 }

--- a/src/app/likes/likes.component.css
+++ b/src/app/likes/likes.component.css
@@ -1,0 +1,16 @@
+:host {
+  align-items: center;
+  display: flex;
+  height: 95%;
+  justify-content: center;
+  color: #717f77;
+}
+
+::ng-deep .mat-progress-spinner circle,
+.mat-spinner circle {
+  stroke: #dae59b;
+}
+
+.mat-list-item {
+  color: #717f77;
+}

--- a/src/app/likes/likes.component.html
+++ b/src/app/likes/likes.component.html
@@ -1,0 +1,1 @@
+<p>likes works!</p>

--- a/src/app/likes/likes.component.html
+++ b/src/app/likes/likes.component.html
@@ -1,1 +1,14 @@
-<p>likes works!</p>
+<ng-container *ngIf="likes$ | async as likes; else loading"
+  ><h3 *ngIf="likes.length == 0">No likes!</h3>
+  <mat-list *ngIf="likes.length > 0">
+    <mat-list-item *ngFor="let like of likes">
+      <h2 matLine>{{like.id}}</h2>
+    </mat-list-item>
+  </mat-list>
+</ng-container>
+<ng-template #loading>
+  <mat-progress-spinner
+    strokeWidth="5"
+    [mode]="'indeterminate'"
+  ></mat-progress-spinner>
+</ng-template>

--- a/src/app/likes/likes.component.html
+++ b/src/app/likes/likes.component.html
@@ -9,6 +9,6 @@
 <ng-template #loading>
   <mat-progress-spinner
     strokeWidth="5"
-    [mode]="'indeterminate'"
+    mode="indeterminate"
   ></mat-progress-spinner>
 </ng-template>

--- a/src/app/likes/likes.component.html
+++ b/src/app/likes/likes.component.html
@@ -1,10 +1,24 @@
 <ng-container *ngIf="likes$ | async as likes; else loading"
   ><h3 *ngIf="likes.length == 0">No likes!</h3>
-  <mat-list *ngIf="likes.length > 0">
-    <mat-list-item *ngFor="let like of likes">
-      <h2 matLine>{{like.id}}</h2>
-    </mat-list-item>
-  </mat-list>
+  <mat-grid-list
+    *ngIf="likes.length > 0"
+    [cols]="likes.length > 4 ? 4 : likes.length"
+    gutterSize="2"
+    rowHeight="1:1"
+    ><a
+      *ngFor="let like of likes"
+      [attr.href]="like.url"
+      target="_blank"
+      title="{{like.title}} by {{like.artist}}"
+    >
+      <mat-grid-tile
+        colspan="1"
+        [style.background-image]="'url(' + like.song_art_image_url + ')' | safe: 'style'"
+        style="background-size: cover;"
+      >
+      </mat-grid-tile>
+    </a>
+  </mat-grid-list>
 </ng-container>
 <ng-template #loading>
   <mat-progress-spinner

--- a/src/app/likes/likes.component.spec.ts
+++ b/src/app/likes/likes.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LikesComponent } from './likes.component';
+
+describe('LikesComponent', () => {
+  let component: LikesComponent;
+  let fixture: ComponentFixture<LikesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LikesComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LikesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/likes/likes.component.spec.ts
+++ b/src/app/likes/likes.component.spec.ts
@@ -78,7 +78,24 @@ describe('LikesComponent', () => {
   }));
 
   it('should display the liked songs', async(() => {
-    const likes = fixture.debugElement.queryAll(By.css('.mat-list'));
+    const mat_list = fixture.debugElement.queryAll(By.css('.mat-list'));
     expect(likes).not.toEqual([]);
+
+    const mat_list_items = fixture.debugElement.queryAll(
+      By.css('.mat-list-item')
+    );
+
+    expect(mat_list_items.length).toEqual(likes.length);
+
+    const like_ids = likes.map(({id}) => id);
+    const mat_list_item_ids = mat_list_items.map(
+      list_item => +list_item.nativeElement.textContent
+    );
+
+    expect(like_ids).toEqual(mat_list_item_ids);
+
+    for (let list_item of mat_list_items) {
+      expect(list_item.classes['mat-list-item']).toBeTruthy();
+    }
   }));
 });

--- a/src/app/likes/likes.component.spec.ts
+++ b/src/app/likes/likes.component.spec.ts
@@ -1,6 +1,6 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { LikesComponent } from './likes.component';
+import {LikesComponent} from './likes.component';
 
 describe('LikesComponent', () => {
   let component: LikesComponent;
@@ -8,9 +8,8 @@ describe('LikesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LikesComponent ]
-    })
-    .compileComponents();
+      declarations: [LikesComponent],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/likes/likes.component.spec.ts
+++ b/src/app/likes/likes.component.spec.ts
@@ -10,6 +10,7 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 
+import {SafePipeModule} from 'safe-pipe';
 import {MaterialModule} from '../material/material.module';
 
 import {AngularFireModule} from '@angular/fire';
@@ -29,8 +30,36 @@ describe('LikesComponent', () => {
   const idToken: string = 'idToken';
 
   const likes: Like[] = [
-    {uid: 'uid1', id: 0},
-    {uid: 'uid1', id: 1},
+    {
+      album: 'Depression Cherry',
+      apple_music_player_url:
+        'https://genius.com/songs/1929412/apple_music_player',
+      artist: 'Beach House',
+      email: 'moot@gmail.com',
+      embed_content:
+        "<div id='rg_embed_link_1929412' class='rg_embed_link' data-song-id='1929412'>Read <a href='https://genius.com/Beach-house-space-song-lyrics'>“Space Song” by Beach House</a> on Genius</div> <script crossorigin src='//genius.com/songs/1929412/embed.js'></script>",
+      id: 1929412,
+      song_art_image_url:
+        'https://images.genius.com/98ce1842b01c032eef50b8726fbbfba6.900x900x1.jpg',
+      title: 'Space Song',
+      uid: 'u1d',
+      url: 'https://genius.com/Beach-house-space-song-lyrics',
+    },
+    {
+      album: 'Non-Album Single',
+      apple_music_player_url:
+        'https://genius.com/songs/2979924/apple_music_player',
+      artist: 'Men I Trust',
+      email: 'moot@gmail.com',
+      embed_content:
+        "<div id='rg_embed_link_2979924' class='rg_embed_link' data-song-id='2979924'>Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>“Lauren” by Men I Trust</a> on Genius</div> <script crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+      id: 2979924,
+      song_art_image_url:
+        'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.1000x1000x1.jpg',
+      title: 'Lauren',
+      uid: 'u1d',
+      url: 'https://genius.com/Men-i-trust-lauren-lyrics',
+    },
   ];
 
   beforeEach(async(() => {
@@ -49,6 +78,7 @@ describe('LikesComponent', () => {
       imports: [
         HttpClientTestingModule,
         MaterialModule,
+        SafePipeModule,
         AngularFireModule.initializeApp(environment.firebaseConfig),
       ],
       declarations: [LikesComponent],
@@ -78,7 +108,7 @@ describe('LikesComponent', () => {
   }));
 
   it('should display the liked songs', async(() => {
-    const likes = fixture.debugElement.queryAll(By.css('.mat-list'));
+    const likes = fixture.debugElement.queryAll(By.css('.mat-grid-list'));
     expect(likes).not.toEqual([]);
   }));
 });

--- a/src/app/likes/likes.component.spec.ts
+++ b/src/app/likes/likes.component.spec.ts
@@ -79,7 +79,7 @@ describe('LikesComponent', () => {
 
   it('should display the liked songs', async(() => {
     const mat_list = fixture.debugElement.queryAll(By.css('.mat-list'));
-    expect(likes).not.toEqual([]);
+    expect(mat_list).not.toEqual([]);
 
     const mat_list_items = fixture.debugElement.queryAll(
       By.css('.mat-list-item')

--- a/src/app/likes/likes.component.ts
+++ b/src/app/likes/likes.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-likes',
+  templateUrl: './likes.component.html',
+  styleUrls: ['./likes.component.css']
+})
+export class LikesComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/likes/likes.component.ts
+++ b/src/app/likes/likes.component.ts
@@ -1,15 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'app-likes',
   templateUrl: './likes.component.html',
-  styleUrls: ['./likes.component.css']
+  styleUrls: ['./likes.component.css'],
 })
-export class LikesComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+export class LikesComponent {
+  constructor() {}
 }

--- a/src/app/likes/likes.component.ts
+++ b/src/app/likes/likes.component.ts
@@ -1,15 +1,25 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit} from '@angular/core';
+
+import {Observable} from 'rxjs';
+import {flatMap} from 'rxjs/operators';
+
+import {Like} from '../models/like.model';
+
+import {AuthService} from '../auth.service';
 
 @Component({
   selector: 'app-likes',
   templateUrl: './likes.component.html',
-  styleUrls: ['./likes.component.css']
+  styleUrls: ['./likes.component.css'],
 })
-export class LikesComponent implements OnInit {
+export class LikesComponent {
+  likes$: Observable<Like[]>;
 
-  constructor() { }
-
-  ngOnInit(): void {
+  constructor(public authService: AuthService) {
+    this.likes$ = authService.authenticateWithGoogle().pipe(
+      flatMap((idToken: string) => {
+        return authService.getLikes(idToken);
+      })
+    );
   }
-
 }

--- a/src/app/likes/likes.component.ts
+++ b/src/app/likes/likes.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-likes',

--- a/src/app/models/like.model.ts
+++ b/src/app/models/like.model.ts
@@ -1,0 +1,4 @@
+export interface Like {
+  id?: number;
+  uid?: string;
+}

--- a/src/app/models/like.model.ts
+++ b/src/app/models/like.model.ts
@@ -1,4 +1,6 @@
 export interface Like {
+  /** ID of song in Genius */
   id?: number;
+  /** Firebase ID of user that liked this song */
   uid?: string;
 }

--- a/src/app/models/like.model.ts
+++ b/src/app/models/like.model.ts
@@ -1,4 +1,12 @@
 export interface Like {
+  album?: string;
+  apple_music_player_url?: string;
+  artist?: string;
+  email?: string;
+  embed_content?: string;
   id?: number;
+  song_art_image_url?: string;
+  title?: string;
   uid?: string;
+  url?: string;
 }

--- a/src/app/models/recommendation.model.ts
+++ b/src/app/models/recommendation.model.ts
@@ -3,8 +3,10 @@ export interface Recommendation {
   apple_music_player_url?: string;
   artist?: string;
   embed_content?: string;
+  /** ID of song in Genius */
   id?: number;
   song_art_image_url?: string;
   title?: string;
+  /** URL to this song's page on genius.com */
   url?: string;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,19 +14,17 @@ body {
 
 body .mat-app-background {
   background-color: #f1f1e7;
-  height: 100%;
+  height: auto;
+  min-height: 100%;
 }
 
 .mat-icon-button {
   color: #6b6a64;
 }
 
+mat-progress-spinner,
 mat-spinner {
   margin-left: auto;
   margin-right: auto;
-}
-
-mat-progress-spinner {
-  margin-left: auto;
-  margin-right: auto;
+  margin-top: 23vh;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,15 @@ body {
   padding: 0;
 }
 
+body .mat-app-background {
+  background-color: #f1f1e7;
+  height: 100%;
+}
+
+.mat-icon-button {
+  color: #6b6a64;
+}
+
 mat-spinner {
   margin-left: auto;
   margin-right: auto;

--- a/test_bigquery.py
+++ b/test_bigquery.py
@@ -1,4 +1,5 @@
 """Tests for bigquery.py"""
+import json
 from unittest.mock import patch
 from absl.testing import absltest # pylint: disable=no-name-in-module
 from utilities import bigquery, firebase
@@ -9,18 +10,43 @@ class TestBigQuery(absltest.TestCase):
         """Set-up
         """
         self.decoded_jwt = {
-            'uid': 'f00'
+            'uid': 'u1d'
         }
-        # TODO Will update with _real_ 'likes' data when like-functionality implemented
         self.likes = [
             {
-                'id': 0,
-                'uid': 'f00',
+                "album": "Depression Cherry",
+                "apple_music_player_url": "https://genius.com/songs/1929412/apple_music_player",
+                "artist": "Beach House",
+                "email": "moot@gmail.com",
+                "embed_content": "<div id='rg_embed_link_1929412' class='rg_embed_link' " \
+                    "data-song-id='1929412'>Read <a " \
+                    "href='https://genius.com/Beach-house-space-song-lyrics'>“Space Song” " \
+                    "by Beach House</a> on Genius</div> <script crossorigin " \
+                    "src='//genius.com/songs/1929412/embed.js'></script>",
+                "id": 1929412,
+                "song_art_image_url":
+                    "https://images.genius.com/98ce1842b01c032eef50b8726fbbfba6.900x900x1.jpg",
+                "title": "Space Song",
+                "uid": "u1d",
+                "url": "https://genius.com/Beach-house-space-song-lyrics"
             },
             {
-                'id': 1,
-                'uid': 'f00',
-            },
+                "album": "Non-Album Single",
+                "apple_music_player_url": "https://genius.com/songs/2979924/apple_music_player",
+                "artist": "Men I Trust",
+                "email": "moot@gmail.com",
+                "embed_content": "<div id='rg_embed_link_2979924' class='rg_embed_link' " \
+                    "data-song-id='2979924'>Read <a " \
+                    "href='https://genius.com/Men-i-trust-lauren-lyrics'>“Lauren” " \
+                    "by Men I Trust</a> on Genius</div> <script crossorigin " \
+                    "src='//genius.com/songs/2979924/embed.js'></script>",
+                "id": 2979924,
+                "song_art_image_url":
+                    "https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.1000x1000x1.jpg",
+                "title": "Lauren",
+                "uid": "u1d",
+                "url": "https://genius.com/Men-i-trust-lauren-lyrics"
+            }
         ]
 
     @patch.object(bigquery.db, 'query')
@@ -28,10 +54,43 @@ class TestBigQuery(absltest.TestCase):
     def test_get_likes(self, mock_verify_id_token, mock_query):
         """Test getting liked songs for logged in user"""
         mock_verify_id_token.return_value = self.decoded_jwt
-        mock_query.return_value = [
-            ['{"id":0,"uid":"f00"}'],
-            ['{"id":1,"uid":"f00"}'],
+        expected_query_results = [
+            {
+                'album': 'Depression Cherry',
+                'apple_music_player_url': 'https://genius.com/songs/1929412/apple_music_player',
+                'artist': 'Beach House',
+                'email': 'moot@gmail.com',
+                'embed_content': "<div id='rg_embed_link_1929412' class='rg_embed_link' " \
+                    "data-song-id='1929412'>Read <a " \
+                    "href='https://genius.com/Beach-house-space-song-lyrics'>“Space Song” " \
+                    "by Beach House</a> on Genius</div> <script crossorigin " \
+                    "src='//genius.com/songs/1929412/embed.js'></script>",
+                'id': 1929412,
+                'song_art_image_url':
+                    'https://images.genius.com/98ce1842b01c032eef50b8726fbbfba6.900x900x1.jpg',
+                'title': 'Space Song',
+                'uid': 'u1d',
+                'url': 'https://genius.com/Beach-house-space-song-lyrics',
+            },
+            {
+                'album': 'Non-Album Single',
+                'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
+                'artist': 'Men I Trust',
+                'email': 'moot@gmail.com',
+                'embed_content': "<div id='rg_embed_link_2979924' class='rg_embed_link' " \
+                    "data-song-id='2979924'>Read <a " \
+                    "href='https://genius.com/Men-i-trust-lauren-lyrics'>“Lauren” " \
+                    "by Men I Trust</a> on Genius</div> <script " \
+                    "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+                'id': 2979924,
+                'song_art_image_url':
+                    'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.1000x1000x1.jpg',
+                'title': 'Lauren',
+                'uid': 'u1d',
+                'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
+            }
         ]
+        mock_query.return_value = [[json.dumps(row)] for row in expected_query_results]
         likes = bigquery.get_likes('idT0ken')
         self.assertEqual(likes, self.likes)
 

--- a/test_bigquery.py
+++ b/test_bigquery.py
@@ -1,0 +1,39 @@
+"""Tests for bigquery.py"""
+from unittest.mock import patch
+from absl.testing import absltest # pylint: disable=no-name-in-module
+from utilities import bigquery, firebase
+
+class TestBigQuery(absltest.TestCase):
+    """BigQuery Testing Class"""
+    def setUp(self): # pylint: disable=invalid-name
+        """Set-up
+        """
+        self.decoded_jwt = {
+            'uid': 'f00'
+        }
+        # TODO Will update with _real_ 'likes' data when like-functionality implemented
+        self.likes = [
+            {
+                'id': 0,
+                'uid': 'f00',
+            },
+            {
+                'id': 1,
+                'uid': 'f00',
+            },
+        ]
+
+    @patch.object(bigquery.db, 'query')
+    @patch.object(firebase.auth, 'verify_id_token')
+    def test_get_likes(self, mock_verify_id_token, mock_query):
+        """Test getting liked songs for logged in user"""
+        mock_verify_id_token.return_value = self.decoded_jwt
+        mock_query.return_value = [
+            ['{"id":0,"uid":"f00"}'],
+            ['{"id":1,"uid":"f00"}'],
+        ]
+        likes = bigquery.get_likes('idT0ken')
+        self.assertEqual(likes, self.likes)
+
+if __name__ == '__main__':
+    absltest.main()

--- a/utilities/bigquery.py
+++ b/utilities/bigquery.py
@@ -1,0 +1,22 @@
+"""Utilities to Interact with BigQuery"""
+import json
+from firebase_admin import auth
+from google.cloud import bigquery
+
+db = bigquery.Client()
+
+def get_likes(id_token):
+    """Gets liked songs for the logged in user."""
+    # TODO Guard against potential failures (?)
+    uid = auth.verify_id_token(id_token)['uid']
+    query = f'''
+        select
+            data
+        from
+            `faf-starter.firestore.likes_raw_latest`
+        where
+            json_value(data, '$.uid') = '{uid}'
+    '''
+    results = db.query(query)
+    likes = [json.loads(row[0]) for row in results]
+    return likes


### PR DESCRIPTION
- [x] Create route to query BigQuery table for `likes` (collection) data exported from Firestore to BigQuery

NOTE:
  - `likes` _data model_ will be updated once **liking** functionality is implemented on the client-side and includes (user) `email`, `artist`, `title`, `album`, etc. but still TBD