### PR TITLE
Like-Song Feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,3 +64,13 @@ def get_likes():
         return flask.abort(401, 'User not logged in!')
     likes = bigquery.get_likes(id_token)
     return flask.jsonify(likes)
+
+@app.route('/_like', methods=['POST'])
+def post_like():
+    """Adds song to verified user's list of liked songs."""
+    id_token = flask.request.headers['Authorization'].split(' ').pop()
+    if not firebase.logged_in(id_token):
+        return flask.abort(401, 'User not logged in!')
+    song = flask.request.get_json()
+    like = firebase.like_song(id_token, song)
+    return flask.jsonify(like)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ attrs==19.3.0
 gunicorn==20.0.4
 firebase-admin==4.3.0
 google-cloud-bigquery==1.28.0
+google-cloud-firestore==1.9.0

--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -56,13 +56,19 @@ describe('AuthService', () => {
     expect(service).toBeTruthy();
   });
 
-  it(`should authenticate user with Google pop-up and return user's ID token`, done => {
+  it('should authenticate user with Google pop-up, if no user signed in', done => {
     service.user = mockAngularFireAuth.onAuthStateChanged();
     service.authenticateWithGoogle().subscribe(result => {
       expect(mockAngularFireAuth.signInWithPopup).toHaveBeenCalledWith(
         new auth.GoogleAuthProvider()
       );
-      expect(mockAngularFireAuth.currentUser).toBeTruthy();
+      done();
+    });
+  });
+
+  it(`should get the signed in user's ID token`, done => {
+    expect(mockAngularFireAuth.currentUser).toBeTruthy();
+    service.getIdToken().subscribe(result => {
       expect(result).toEqual(idToken);
       done();
     });

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -20,7 +20,7 @@
         mat-icon-button
         title="Like"
         [disabled]="liked.status"
-        (click)="likeRecommendation(recommendation)"
+        (click)="!liked.status && likeClicked.next(recommendation)"
         ><mat-icon>{{liked.status ? 'check' : 'add'}}</mat-icon></a
       >
       <a mat-icon-button title="Next Track" (click)="window.location.reload()"

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -21,7 +21,7 @@
         title="Like"
         [disabled]="liked.status"
         (click)="likeRecommendation(recommendation)"
-        ><mat-icon>{{!liked.status ? 'add': 'check'}}</mat-icon></a
+        ><mat-icon>{{liked.status ? 'check' : 'add'}}</mat-icon></a
       >
       <a mat-icon-button title="Next Track" (click)="window.location.reload()"
         ><mat-icon>skip_next</mat-icon></a

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -16,11 +16,22 @@
     </mat-card-content>
     <mat-card-actions>
       <a
+        *ngIf="{status: liked$ | async} as liked"
+        mat-icon-button
+        title="Like"
+        [disabled]="liked.status"
+        (click)="likeRecommendation(recommendation)"
+        ><mat-icon>{{!liked.status ? 'add': 'check'}}</mat-icon></a
+      >
+      <a mat-icon-button title="Next Track" (click)="window.location.reload()"
+        ><mat-icon>skip_next</mat-icon></a
+      >
+      <a
         mat-icon-button
         title="Lyrics"
         target="_blank"
         [attr.href]="recommendation.url"
-        ><mat-icon>article</mat-icon>
+        ><mat-icon>art_track</mat-icon>
       </a>
     </mat-card-actions>
   </mat-card>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -32,7 +32,10 @@ export class HomeComponent {
       ),
       map((song: Recommendation) => this.validateRecommendation(song))
     );
-    this.liked$ = this.likeClicked.pipe(this.likeRecommendation);
+    this.liked$ = this.likeClicked.pipe(
+      this.likeRecommendation,
+      startWith(false)
+    );
   }
 
   /** Validates/processes song recommendation. */
@@ -50,7 +53,6 @@ export class HomeComponent {
     flatMap(([song, idToken]: [Recommendation, string]) =>
       this.httpService.post<Like>(idToken, song, '_like')
     ),
-    map((like: Like) => !!like),
-    startWith(false)
+    map((like: Like) => !!like)
   );
 }

--- a/src/app/http.service.spec.ts
+++ b/src/app/http.service.spec.ts
@@ -30,6 +30,22 @@ describe('HttpService', () => {
     url: 'https://genius.com/Jacob-collier-sleeping-on-my-dreams-lyrics',
   };
 
+  const like: Like = {
+    album: 'Djesse, Vol. 3',
+    apple_music_player_url:
+      'https://genius.com/songs/5751704/apple_music_player',
+    artist: 'Jacob Collier',
+    email: 'moot@gmail.com',
+    embed_content:
+      "<div id='rg_embed_link_5751704' class='rg_embed_link' data-song-id='5751704'>Read <a href='https://genius.com/Jacob-collier-sleeping-on-my-dreams-lyrics'>“Sleeping on My Dreams” by Jacob Collier</a> on Genius</div> <script crossorigin src='//genius.com/songs/5751704/embed.js'></script>",
+    id: 5751704,
+    song_art_image_url:
+      'https://images.genius.com/b5f4dda4b90c2171639783c1f6eeeddb.1000x1000x1.jpg',
+    title: 'Sleeping on My Dreams',
+    uid: 'u1d',
+    url: 'https://genius.com/Jacob-collier-sleeping-on-my-dreams-lyrics',
+  };
+
   const likes: Like[] = [
     {
       album: 'Depression Cherry',
@@ -105,6 +121,23 @@ describe('HttpService', () => {
       expect(req.request.method).toEqual('GET');
 
       req.flush(likes);
+    }
+  ));
+
+  it('should request to _like_ the recommendation and return the `Like`', inject(
+    [HttpTestingController, HttpService],
+    (httpMock: HttpTestingController, httpService: HttpService) => {
+      const endpoint = '_like';
+
+      httpService
+        .post<Like>(idToken, recommendation, endpoint)
+        .subscribe(response => expect(response).toEqual(like));
+
+      const req = httpMock.expectOne(environment.url + endpoint);
+
+      expect(req.request.method).toEqual('POST');
+
+      req.flush(like);
     }
   ));
 

--- a/src/app/http.service.ts
+++ b/src/app/http.service.ts
@@ -16,9 +16,16 @@ export class HttpService {
     this.headers = new HttpHeaders({'Content-Type': 'application/json'});
   }
 
-  /** Returns an Observable for HTTP response object. */
+  /** Sends HTTP GET request to server. */
   get<T>(idToken: string, endpoint: string): Observable<T> {
     return this.http.get<T>(environment.url + endpoint, {
+      headers: this.headers.append('Authorization', 'Bearer ' + idToken),
+    });
+  }
+
+  /** Sends HTTP POST request to server. */
+  post<T>(idToken: string, data: any, endpoint: string): Observable<T> {
+    return this.http.post<T>(environment.url + endpoint, data, {
       headers: this.headers.append('Authorization', 'Bearer ' + idToken),
     });
   }

--- a/src/app/likes/likes.component.css
+++ b/src/app/likes/likes.component.css
@@ -10,6 +10,10 @@
   stroke: #dae59b;
 }
 
+h3 {
+  margin-top: 23vh;
+}
+
 .mat-grid-list {
   margin-top: 3vh;
   width: 75%;

--- a/src/app/likes/likes.component.spec.ts
+++ b/src/app/likes/likes.component.spec.ts
@@ -29,9 +29,15 @@ describe('LikesComponent', () => {
   let authService;
   let httpService;
   let authenticateWithGoogleSpy;
+  let getIdTokenSpy;
   let getSpy;
 
   const idToken: string = 'idToken';
+
+  const credential = {
+    user: {},
+    credential: {},
+  };
 
   const likes: Like[] = [
     {
@@ -69,13 +75,16 @@ describe('LikesComponent', () => {
   beforeEach(async(() => {
     authService = jasmine.createSpyObj('AuthService', [
       'authenticateWithGoogle',
+      'getIdToken',
     ]);
 
     httpService = jasmine.createSpyObj('HttpService', ['get']);
 
     authenticateWithGoogleSpy = authService.authenticateWithGoogle.and.returnValue(
-      of(idToken)
+      of(credential)
     );
+
+    getIdTokenSpy = authService.getIdToken.and.returnValue(of(idToken));
 
     getSpy = httpService.get.and.returnValue(of(likes));
 
@@ -106,6 +115,7 @@ describe('LikesComponent', () => {
 
   it('should attempt to authenticate user then get their liked songs', async(() => {
     expect(authenticateWithGoogleSpy.calls.any()).toBe(true);
+    expect(getIdTokenSpy.calls.any()).toBe(true);
     expect(getSpy.calls.any()).toBe(true);
   }));
 

--- a/src/app/likes/likes.component.ts
+++ b/src/app/likes/likes.component.ts
@@ -14,19 +14,15 @@ import {HttpService} from '../http.service';
   styleUrls: ['./likes.component.css'],
 })
 export class LikesComponent {
-  endpoint: string = '_likes';
   likes$: Observable<Like[]>;
 
   constructor(
     public authService: AuthService,
     public httpService: HttpService
   ) {
-    this.likes$ = authService
-      .authenticateWithGoogle()
-      .pipe(
-        flatMap((idToken: string) =>
-          httpService.get<Like[]>(idToken, this.endpoint)
-        )
-      );
+    this.likes$ = authService.authenticateWithGoogle().pipe(
+      flatMap(() => authService.getIdToken()),
+      flatMap((idToken: string) => httpService.get<Like[]>(idToken, '_likes'))
+    );
   }
 }

--- a/src/app/models/like.model.ts
+++ b/src/app/models/like.model.ts
@@ -10,5 +10,6 @@ export interface Like {
   title?: string;
   /** Firebase ID of user that liked this song */
   uid?: string;
+  /** URL to this song's page on genius.com */
   url?: string;
 }

--- a/test_app.py
+++ b/test_app.py
@@ -34,6 +34,23 @@ class TestFlaskApp(absltest.TestCase):
             'title': 'Lauren',
             'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
         }
+        self.like = {
+            'album': None,
+            'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
+            'artist': 'Men I Trust',
+            'email': 'moot@gmail.com',
+            'embed_content': "<div id='rg_embed_link_2979924' " \
+                "class='rg_embed_link' data-song-id='2979924'>" \
+                "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
+                "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
+                "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+            'id': 2979924,
+            'song_art_image_thumbnail_url': \
+                'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
+            'title': 'Lauren',
+            'uid': 'u1d',
+            'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
+        }
         self.likes = [
             {
                 'id': 0,
@@ -79,6 +96,18 @@ class TestFlaskApp(absltest.TestCase):
         self.assertEqual(response.headers['Content-Type'], 'application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(likes, self.likes)
+
+    @patch.object(firebase, 'like_song')
+    @patch.object(firebase, 'logged_in')
+    def test_post_like(self, mock_logged_in, mock_like_song):
+        """Test hitting the '_like' endpoint to add the song recommendation"""
+        mock_logged_in.return_value = True
+        mock_like_song.return_value = self.like
+        response = self.api.post('/_like', json.dumps(self.song), headers=self.headers)
+        like = json.loads(response.text)
+        self.assertEqual(response.headers['Content-Type'], 'application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(like, self.like)
 
 if __name__ == '__main__':
     absltest.main()

--- a/test_app.py
+++ b/test_app.py
@@ -35,7 +35,7 @@ class TestFlaskApp(absltest.TestCase):
             'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
         }
         self.like = {
-            'album': None,
+            'album': 'Non-Album Single',
             'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
             'artist': 'Men I Trust',
             'email': 'moot@gmail.com',

--- a/test_firebase.py
+++ b/test_firebase.py
@@ -8,7 +8,7 @@ class TestFirebase(absltest.TestCase):
     """Firebase Testing Class"""
     def setUp(self): # pylint: disable=invalid-name
         """Set-up
-            Mock ID token, jwt, song, and like
+            Mock ID token, jwt, song, like, and transaction
         """
         self.id_token = 'idT0ken'
         self.jwt = {

--- a/test_firebase.py
+++ b/test_firebase.py
@@ -1,62 +1,67 @@
 """Tests for firebase.py"""
-from unittest.mock import patch
+from unittest import mock
 from absl.testing import absltest # pylint: disable=no-name-in-module
 from firebase_admin import auth
 from utilities import firebase
 
 class TestFirebase(absltest.TestCase):
     """Firebase Testing Class"""
-    def setUp(self): # pylint: disable=invalid-name
-        """Set-up
-            Mock ID token, jwt, song, like, and transaction
-        """
-        self.id_token = 'idT0ken'
-        self.jwt = {
-            'email': 'moot@gmail.com',
-            'uid': 'f00',
-        }
-        self.song = {
-            'album': None,
-            'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
-            'artist': 'Men I Trust',
-            'embed_content': "<div id='rg_embed_link_2979924' " \
-                "class='rg_embed_link' data-song-id='2979924'>" \
-                "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
-                "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
-                "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
-            'id': 2979924,
-            'song_art_image_thumbnail_url': \
-                'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
-            'title': 'Lauren',
-            'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
-        }
-        self.like = {
-            'album': 'Non-Album Single',
-            'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
-            'artist': 'Men I Trust',
-            'email': 'moot@gmail.com',
-            'embed_content': "<div id='rg_embed_link_2979924' " \
-                "class='rg_embed_link' data-song-id='2979924'>" \
-                "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
-                "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
-                "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
-            'id': 2979924,
-            'song_art_image_thumbnail_url': \
-                'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
-            'title': 'Lauren',
-            'uid': 'u1d',
-            'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
-        }
-        self.transaction = firebase.db.transaction()
+    id_token = 'idT0ken'
+    jwt = {
+        'email': 'moot@gmail.com',
+        'uid': 'f00',
+    }
+    song = {
+        'album': None,
+        'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
+        'artist': 'Men I Trust',
+        'embed_content': "<div id='rg_embed_link_2979924' " \
+            "class='rg_embed_link' data-song-id='2979924'>" \
+            "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
+            "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
+            "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+        'id': 2979924,
+        'song_art_image_thumbnail_url': \
+            'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
+        'title': 'Lauren',
+        'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
+    }
+    like = {
+        'album': 'Non-Album Single',
+        'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
+        'artist': 'Men I Trust',
+        'email': 'moot@gmail.com',
+        'embed_content': "<div id='rg_embed_link_2979924' " \
+            "class='rg_embed_link' data-song-id='2979924'>" \
+            "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
+            "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
+            "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+        'id': 2979924,
+        'song_art_image_thumbnail_url': \
+            'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
+        'title': 'Lauren',
+        'uid': 'u1d',
+        'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
+    }
+    transaction = mock.MagicMock()
 
-    @patch.object(firebase.auth, 'verify_id_token')
+    @classmethod
+    def setUp(cls): # pylint: disable=invalid-name
+        """Set-up
+            * Mock Firestore database
+            * Mock return value for query agaist Firestore db
+        """
+        firebase.db = mock.MagicMock()
+        firebase.db.collection().where().where().get.return_value = []
+
+    @mock.patch.object(firebase.auth, 'verify_id_token')
     def test_logged_in(self, mock_verify_id_token):
         """Test checking if a user is logged in"""
         mock_verify_id_token.return_value = self.jwt
         logged_in = firebase.logged_in(self.id_token)
         self.assertTrue(logged_in)
 
-    @patch.object(firebase.auth, 'verify_id_token')
+    @mock.patch.object(firebase.auth, 'verify_id_token')
     def test_not_logged_in(self, mock_verify_id_token):
         """Test checking if a user is _not_ logged in"""
         mock_verify_id_token.side_effect = \
@@ -64,15 +69,15 @@ class TestFirebase(absltest.TestCase):
         logged_in = firebase.logged_in(self.id_token)
         self.assertFalse(logged_in)
 
-    @patch.object(firebase.auth, 'verify_id_token')
+    @mock.patch.object(firebase.auth, 'verify_id_token')
     def test_get_song_id(self, mock_verify_id_token):
         """Test getting song (ID) recommendation"""
         mock_verify_id_token.return_value = self.jwt
         song_id = firebase.get_song_id(self.id_token)
         self.assertIsInstance(song_id, int)
 
-    @patch.object(firebase, 'set_like')
-    @patch.object(firebase.auth, 'verify_id_token')
+    @mock.patch.object(firebase, 'set_like')
+    @mock.patch.object(firebase.auth, 'verify_id_token')
     def test_like_song(self, mock_verify_id_token, mock_set_like):
         """Test liking song recommendation"""
         mock_verify_id_token.return_value = self.jwt
@@ -83,6 +88,15 @@ class TestFirebase(absltest.TestCase):
     def test_set_like(self):
         """Test transaction of adding a song"""
         like = firebase.set_like(self.transaction, self.like)
+        firebase.db.collection.assert_called_with(u'likes')
+        firebase.db.collection() \
+            .where.assert_called_with(u'uid', u'==', u'{}'.format(self.like['uid']))
+        firebase.db.collection() \
+            .where().where.assert_called_with(u'id', u'==', self.like['id'])
+        firebase.db.collection() \
+            .where().where().get.assert_called_with(transaction=self.transaction)
+        self.transaction.set.assert_called_with( \
+            firebase.db.collection(u'likes').document(), self.like)
         self.assertEqual(like, self.like)
 
 if __name__ == '__main__':

--- a/test_firebase.py
+++ b/test_firebase.py
@@ -31,7 +31,7 @@ class TestFirebase(absltest.TestCase):
             'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
         }
         self.like = {
-            'album': None,
+            'album': 'Non-Album Single',
             'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
             'artist': 'Men I Trust',
             'email': 'moot@gmail.com',

--- a/test_firebase.py
+++ b/test_firebase.py
@@ -2,27 +2,58 @@
 from unittest.mock import patch
 from absl.testing import absltest # pylint: disable=no-name-in-module
 from firebase_admin import auth
-from mockfirestore import MockFirestore
 from utilities import firebase
 
 class TestFirebase(absltest.TestCase):
     """Firebase Testing Class"""
-    decoded_jwt = {
-        'uid': 'f00',
-    }
-
-    @classmethod
-    def setUp(cls): # pylint: disable=invalid-name
+    def setUp(self): # pylint: disable=invalid-name
         """Set-up
-            * Mock Firestore database
+            Mock ID token, jwt, song, and like
         """
-        firebase.db = MockFirestore()
+        self.id_token = 'idT0ken'
+        self.jwt = {
+            'email': 'moot@gmail.com',
+            'uid': 'f00',
+        }
+        self.song = {
+            'album': None,
+            'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
+            'artist': 'Men I Trust',
+            'embed_content': "<div id='rg_embed_link_2979924' " \
+                "class='rg_embed_link' data-song-id='2979924'>" \
+                "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
+                "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
+                "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+            'id': 2979924,
+            'song_art_image_thumbnail_url': \
+                'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
+            'title': 'Lauren',
+            'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
+        }
+        self.like = {
+            'album': None,
+            'apple_music_player_url': 'https://genius.com/songs/2979924/apple_music_player',
+            'artist': 'Men I Trust',
+            'email': 'moot@gmail.com',
+            'embed_content': "<div id='rg_embed_link_2979924' " \
+                "class='rg_embed_link' data-song-id='2979924'>" \
+                "Read <a href='https://genius.com/Men-i-trust-lauren-lyrics'>" \
+                "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
+                "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
+            'id': 2979924,
+            'song_art_image_thumbnail_url': \
+                'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
+            'title': 'Lauren',
+            'uid': 'u1d',
+            'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
+        }
+        self.transaction = firebase.db.transaction()
 
     @patch.object(firebase.auth, 'verify_id_token')
     def test_logged_in(self, mock_verify_id_token):
         """Test checking if a user is logged in"""
-        mock_verify_id_token.return_value = self.decoded_jwt
-        logged_in = firebase.logged_in('good_idT0ken')
+        mock_verify_id_token.return_value = self.jwt
+        logged_in = firebase.logged_in(self.id_token)
         self.assertTrue(logged_in)
 
     @patch.object(firebase.auth, 'verify_id_token')
@@ -30,15 +61,29 @@ class TestFirebase(absltest.TestCase):
         """Test checking if a user is _not_ logged in"""
         mock_verify_id_token.side_effect = \
             auth.InvalidIdTokenError('InvalidIdTokenError')
-        logged_in = firebase.logged_in('bad_idT0ken')
+        logged_in = firebase.logged_in(self.id_token)
         self.assertFalse(logged_in)
 
     @patch.object(firebase.auth, 'verify_id_token')
     def test_get_song_id(self, mock_verify_id_token):
         """Test getting song (ID) recommendation"""
-        mock_verify_id_token.return_value = self.decoded_jwt
-        song_id = firebase.get_song_id('idT0ken')
+        mock_verify_id_token.return_value = self.jwt
+        song_id = firebase.get_song_id(self.id_token)
         self.assertIsInstance(song_id, int)
+
+    @patch.object(firebase, 'set_like')
+    @patch.object(firebase.auth, 'verify_id_token')
+    def test_like_song(self, mock_verify_id_token, mock_set_like):
+        """Test liking song recommendation"""
+        mock_verify_id_token.return_value = self.jwt
+        mock_set_like.return_value = self.like
+        like = firebase.like_song(self.id_token, self.song)
+        self.assertEqual(like, self.like)
+
+    def test_set_like(self):
+        """Test transaction of adding a song"""
+        like = firebase.set_like(self.transaction, self.like)
+        self.assertEqual(like, self.like)
 
 if __name__ == '__main__':
     absltest.main()

--- a/test_genius.py
+++ b/test_genius.py
@@ -25,7 +25,7 @@ class TestGenius(absltest.TestCase):
                 "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
                 "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
             'id': 2979924,
-            'song_art_image_thumbnail_url': \
+            'song_art_image_url': \
                 'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
             'title': 'Lauren',
             'url': 'https://genius.com/Men-i-trust-lauren-lyrics',
@@ -52,7 +52,7 @@ class TestGenius(absltest.TestCase):
                         "“Lauren” by Men\xa0I Trust</a> on Genius</div> <script " \
                         "crossorigin src='//genius.com/songs/2979924/embed.js'></script>",
                     'id': 2979924,
-                    'song_art_image_thumbnail_url': \
+                    'song_art_image_url': \
                         'https://images.genius.com/9a956e5a7c0d78e8441b31bdf14dc87b.300x300x1.jpg',
                     'title': 'Lauren',
                     'url': 'https://genius.com/Men-i-trust-lauren-lyrics',

--- a/utilities/bigquery.py
+++ b/utilities/bigquery.py
@@ -7,7 +7,6 @@ db = bigquery.Client()
 
 def get_likes(id_token):
     """Gets liked songs for the logged in user."""
-    # TODO Guard against potential failures (?)
     uid = auth.verify_id_token(id_token)['uid']
     query = f'''
         select

--- a/utilities/firebase.py
+++ b/utilities/firebase.py
@@ -17,7 +17,6 @@ def logged_in(id_token):
 
 def get_song_id(id_token):
     """Gets a song ID (recommendation) for the logged in user."""
-    # TODO This seems like a dangerous assumption
     uid = auth.verify_id_token(id_token)['uid']
     # TODO Song selections will be based on multiple factors, e.g. time of day
     songs = {

--- a/utilities/firebase.py
+++ b/utilities/firebase.py
@@ -11,7 +11,6 @@ def logged_in(id_token):
     try:
         auth.verify_id_token(id_token)
     except auth.InvalidIdTokenError:
-        # TODO Include exceptions for ExpiredIdTokenError, RevokedIdTokenError, ...
         return False
     return True
 

--- a/utilities/firebase.py
+++ b/utilities/firebase.py
@@ -18,7 +18,6 @@ def logged_in(id_token):
 def get_song_id(id_token):
     """Gets a song ID (recommendation) for the logged in user."""
     uid = auth.verify_id_token(id_token)['uid']
-    # TODO Song selections will be based on multiple factors, e.g. time of day
     songs = {
         1929408, # Levitation by Beach House
         1929412, # Space Song by Beach House

--- a/utilities/genius.py
+++ b/utilities/genius.py
@@ -17,7 +17,7 @@ def get_song(song_id):
         'artist': song['primary_artist']['name'],
         'embed_content': song['embed_content'],
         'id': song['id'],
-        'song_art_image_thumbnail_url': song['song_art_image_thumbnail_url'],
+        'song_art_image_url': song['song_art_image_url'],
         'title': song['title'],
         'url': song['url'],
     }


### PR DESCRIPTION
- Client-Side
  - [x] Add button/method to send `POST` request to server, with song recommendation data
  - [x] Add button to get a new song recommendation
  - [x] Split up signing-in the user and getting the signed-in user's ID token

- Server-Side
  - [x] Create route to `set()` song recommendation in `likes` collection
  - [x] Switched from `firebase_admin.firestore` to `google.cloud.firestore` to do transactional operations
  - [x] Updated _model_ for song recommendations from the `genius` utility